### PR TITLE
[fix]ルートの記述の変更、管理者のログイン後の遷移先の変更

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -20,7 +20,7 @@ class Admin::SessionsController < Devise::SessionsController
 
   protected
   def after_sign_in_path_for(resource)
-    admin_products_path
+    admin_root_path
   end
 
   def after_sign_out_path_for(resource)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,11 +32,11 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    root to: "admin/homes#top"
+    root to: "homes#top"
     resources :products, except: [:destroy]
     resources :genres, only: [:index, :create, :edit, :update]
     resources :customers, only: [:index, :show, :edit, :update]
-    resources :orders, onlyonly: [:show, :update]
+    resources :orders, only: [:show, :update]
     resources :order_products, only: [:update]
   end
 


### PR DESCRIPTION
routes.rb内の記述の変更
onlyを一箇所修正
namespace :admin do内、既にadminの指定があるのでroot toの"/admin"が不要でした。

管理者がログイン後に遷移する画面を管理者トップ(注文履歴一覧)に変更しました。