### PR TITLE
Feature public/customers/edit

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -29,7 +29,7 @@ class Public::CartItemsController < ApplicationController
       redirect_to products_path
     end
   end
-  
+
   def destroy
     @cart_item = current_customer.cart_items.find(params[:id])
     @cart_item.destroy

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,8 +1,20 @@
 class Public::CustomersController < ApplicationController
+  before_action :authenticate_customer!
+  
   def show
   end
 
   def edit
+    @customer = current_customer
+  end
+
+  def update
+    @customer = current_customer
+    if @customer.update(customer_params)
+      redirect_to customers_path
+    else
+      redirect_to request.referer
+    end
   end
 
   def check
@@ -18,7 +30,9 @@ class Public::CustomersController < ApplicationController
 
 
 
-
-
+  private
+  def customer_params
+    params.require(:customer).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :postal_code, :address, :phone_num, :email)
+  end
 
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -4,7 +4,6 @@ class Customer < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-
   # 退会処理用
   def active_for_authentication?
     super && (is_deleted == false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+         
+
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -40,7 +40,7 @@
               <p class="nav-link text-light mr-5">ようこそ、<%= current_customer.last_name %>さん！</p>
             </li>
             <li>
-              <%= link_to customers_path(current_customer.id) do %>
+              <%= link_to customers_path do %>
                 <div class="nav-link text-light">マイページ</div>
               <%end%>
             </li>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,0 +1,45 @@
+<!--views/public/registrations/edit のコピー-->
+
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "public/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,45 +1,53 @@
-<!--views/public/registrations/edit のコピー-->
+<div class='container shadow-lg'>
+  <div class='row'>
+    <div class="col-lg-8 col-md-10 col-sm-12 mx-6 mx-sm-auto px-auto my-5">
 
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+      <p class= "text-center text-danger"><%= flash[:withdrawal] %></p>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
+      <h3 class="mb-5 border-bottom"><span>会員情報編集</span></h3>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= form_with model: @customer, url: customers_path, method: :patch, local: true do |f| %>
+        <div class="form-group row my-3">
+          <%= f.label :last_name, '名前', class:'col-3' %>
+          <%= f.label :last_name, '(姓)', class:'col-1' %>
+          <%= f.text_field :last_name, autofocus: true, placeholder: "長野", autocomplete: "last_name", class:'col-3 form-control' %>
+          <%= f.label :first_name, '(名)', class:'col-2 text-right' %>
+          <%= f.text_field :first_name, placeholder: "景子", autocomplete: "first_name", class: "name", class:'col-3' %>
+        </div>
+
+        <div class="form-group row my-3">
+          <%= f.label :last_name_kana, 'フリガナ', class:'col-2' %>
+          <%= f.label :last_name_kana, '(セイ)', class:'col-2 text-right'%>
+          <%= f.text_field :last_name_kana, placeholder: "ナガノ", autocomplete: "last_name_kana", class: "col-3" %>
+          <%= f.label :first_name_kana, '(メイ)', class:'col-2 text-right'%>
+          <%= f.text_field :first_name_kana, placeholder: "ケイコ", autocomplete: "first_name_kana", class: "col-3" %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :postal_code, '郵便番号', class:'col-4'%>
+          <%= f.text_field :postal_code, placeholder: "000000", autocomplete: "postal_code", class:'col-3' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :address, '住所', class:'col-4' %>
+          <%= f.text_field :address, placeholder: "長野県菓市美味町1-2-3", autocomplete: "address", class:'col-8' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :phone_num, '電話番号', class:'col-4' %>
+          <%= f.text_field :phone_num, placeholder: "0000000", autocomplete: "phone_num", class:'col-3' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :email, 'メールアドレス', class:'col-4' %>
+          <%= f.email_field :email, placeholder: "nagano@cake.com", autocomplete: "email", class:'col-3' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.submit "編集内容を保存", class:'btn btn-success col-4 offset-4'%>
+          <%= link_to "退会する", check_customers_path, class:'btn btn-danger col-2 offset-2' %>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -6,7 +6,7 @@
 
         <div  class='row pb-3'>
           <h4 class="col-3">登録情報</h4>
-          <%= link_to  '編集する', edit_customer_registration_path, class:"btn btn-outline-success col-3" %>
+          <%= link_to  '編集する', edit_customers_path, class:"btn btn-outline-success col-3" %>
         </div>
 
         <table class="table table-bordered">

--- a/app/views/public/registrations/edit.html.erb
+++ b/app/views/public/registrations/edit.html.erb
@@ -1,43 +1,54 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class='container shadow-lg'>
+  <div class='row'>
+    <div class="col-lg-8 col-md-10 col-sm-12 mx-6 mx-sm-auto px-auto my-5">
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "public/shared/error_messages", resource: resource %>
+      <p class= "text-center text-danger"><%= flash[:withdrawal] %></p>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <h3 class="mb-5 border-bottom"><span>会員情報編集</span></h3>
+
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "public/shared/error_messages", resource: resource %>
+        <div class="form-group row my-3">
+          <%= f.label :last_name, '名前', class:'col-3' %>
+          <%= f.label :last_name, '(姓)', class:'col-1' %>
+          <%= f.text_field :last_name, autofocus: true, placeholder: "長野", autocomplete: "last_name", class:'col-3 form-control' %>
+          <%= f.label :first_name, '(名)', class:'col-2 text-right' %>
+          <%= f.text_field :first_name, placeholder: "景子", autocomplete: "first_name", class: "name", class:'col-3' %>
+        </div>
+
+        <div class="form-group row my-3">
+          <%= f.label :last_name_kana, 'フリガナ', class:'col-2' %>
+          <%= f.label :last_name_kana, '(セイ)', class:'col-2 text-right'%>
+          <%= f.text_field :last_name_kana, placeholder: "ナガノ", autocomplete: "last_name_kana", class: "col-3" %>
+          <%= f.label :first_name_kana, '(メイ)', class:'col-2 text-right'%>
+          <%= f.text_field :first_name_kana, placeholder: "ケイコ", autocomplete: "first_name_kana", class: "col-3" %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :postal_code, '郵便番号', class:'col-4'%>
+          <%= f.text_field :postal_code, placeholder: "000000", autocomplete: "postal_code", class:'col-3' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :address, '住所', class:'col-4' %>
+          <%= f.text_field :address, placeholder: "長野県菓市美味町1-2-3", autocomplete: "address", class:'col-8' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :phone_num, '電話番号', class:'col-4' %>
+          <%= f.text_field :phone_num, placeholder: "0000000", autocomplete: "phone_num", class:'col-3' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :email, 'メールアドレス', class:'col-4' %>
+          <%= f.email_field :email, placeholder: "nagano@cake.com", autocomplete: "email", class:'col-3' %>
+        </div>
+
+        <div class="form-group row">
+          <%= f.submit "編集内容を保存", class:'btn btn-success col-4 offset-4'%>
+          <%= link_to "退会する", check_customers_path, class:'btn btn-danger col-2 offset-2' %>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/public/registrations/edit.html.erb
+++ b/app/views/public/registrations/edit.html.erb
@@ -1,54 +1,43 @@
-<div class='container shadow-lg'>
-  <div class='row'>
-    <div class="col-lg-8 col-md-10 col-sm-12 mx-6 mx-sm-auto px-auto my-5">
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-      <p class= "text-center text-danger"><%= flash[:withdrawal] %></p>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "public/shared/error_messages", resource: resource %>
 
-      <h3 class="mb-5 border-bottom"><span>会員情報編集</span></h3>
-
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= render "public/shared/error_messages", resource: resource %>
-        <div class="form-group row my-3">
-          <%= f.label :last_name, '名前', class:'col-3' %>
-          <%= f.label :last_name, '(姓)', class:'col-1' %>
-          <%= f.text_field :last_name, autofocus: true, placeholder: "長野", autocomplete: "last_name", class:'col-3 form-control' %>
-          <%= f.label :first_name, '(名)', class:'col-2 text-right' %>
-          <%= f.text_field :first_name, placeholder: "景子", autocomplete: "first_name", class: "name", class:'col-3' %>
-        </div>
-
-        <div class="form-group row my-3">
-          <%= f.label :last_name_kana, 'フリガナ', class:'col-2' %>
-          <%= f.label :last_name_kana, '(セイ)', class:'col-2 text-right'%>
-          <%= f.text_field :last_name_kana, placeholder: "ナガノ", autocomplete: "last_name_kana", class: "col-3" %>
-          <%= f.label :first_name_kana, '(メイ)', class:'col-2 text-right'%>
-          <%= f.text_field :first_name_kana, placeholder: "ケイコ", autocomplete: "first_name_kana", class: "col-3" %>
-        </div>
-
-        <div class="form-group row">
-          <%= f.label :postal_code, '郵便番号', class:'col-4'%>
-          <%= f.text_field :postal_code, placeholder: "000000", autocomplete: "postal_code", class:'col-3' %>
-        </div>
-
-        <div class="form-group row">
-          <%= f.label :address, '住所', class:'col-4' %>
-          <%= f.text_field :address, placeholder: "長野県菓市美味町1-2-3", autocomplete: "address", class:'col-8' %>
-        </div>
-
-        <div class="form-group row">
-          <%= f.label :phone_num, '電話番号', class:'col-4' %>
-          <%= f.text_field :phone_num, placeholder: "0000000", autocomplete: "phone_num", class:'col-3' %>
-        </div>
-
-        <div class="form-group row">
-          <%= f.label :email, 'メールアドレス', class:'col-4' %>
-          <%= f.email_field :email, placeholder: "nagano@cake.com", autocomplete: "email", class:'col-3' %>
-        </div>
-
-        <div class="form-group row">
-          <%= f.submit "編集内容を保存", class:'btn btn-success col-4 offset-4'%>
-          <%= link_to "退会する", check_customers_path, class:'btn btn-danger col-2 offset-2' %>
-        </div>
-      <% end %>
-    </div>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
-</div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+
+<%= link_to "Back", :back %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,5 @@
 Rails.application.routes.draw do
 
- # 顧客用
- # URL /customers/sign_in ...
- devise_for :customers,skip: [:passwords], controllers: {
-  registrations: "public/registrations",
-  sessions: 'public/sessions'
- }
-
- # 管理者用
- # URL /admin/sign_in ...
- devise_for :admin, skip: [:registrations, :passwords] , controllers: {
-  sessions: "admin/sessions"
- }
 
   scope module: :public do
     root to: "homes#top"
@@ -31,6 +19,14 @@ Rails.application.routes.draw do
     end
   end
 
+  # 顧客用
+  # URL /customers/sign_in ...
+  devise_for :customers,skip: [:passwords], controllers: {
+    registrations: "public/registrations",
+    sessions: 'public/sessions'
+  }
+
+
   namespace :admin do
     root to: "homes#top"
     resources :products, except: [:destroy]
@@ -39,6 +35,12 @@ Rails.application.routes.draw do
     resources :orders, only: [:show, :update]
     resources :order_products, only: [:update]
   end
+
+  # 管理者用
+  # URL /admin/sign_in ...
+  devise_for :admin, skip: [:registrations, :passwords] , controllers: {
+    sessions: "admin/sessions"
+  }
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
顧客情報編集画面 #48
-- 新規 --
・顧客情報の更新を保存するボタンで、更新されマイページへ遷移。
・退会するボタンで、退会確認画面へ遷移。

-- 変更点 --
・ルーティング一部変更
【経緯】
以下2つの同じURLが存在していた。
① deviseにより作成された"/customers/edit" (edit_customer_registration_path) registration#edit
　 resourcesで作成された"/customers/edit" (edit_customers_path) customers#edit
② deviseにより作成された"/customers" (customer_registration_path) registrations#update
 　resourcesで作成された"/customers" (customers_path) customers#update
画面遷移の際、パスを指定しcustomersのパスへ遷移したかったが、registrationsのパスに遷移してしまう。
【原因】
routes.rbの記述の順番。
パスが異なってもURLが同じため、上に記述されたdeviseのパス(registrations)が優先されていたため。
【解決法】
"devise for :admin..." と "devise for :customers..." の記述位置を下へ移動。

・ヘッダー一部変更
【経緯】
マイページのURLに"/customers.1" と表示されている。
表示されるのはヘッダーのリンクから遷移する場合のみ。
【原因】
views/layouts/_header.html.erb内のマイページへのリンク内の
<%= link_to customers_path(current_customer.id) do %>に含まれる(current_customer.id)
【解決法】
顧客をidで判別する必要はないため、(current_customer.id)という記述を削除。